### PR TITLE
fix character encoding error on init load

### DIFF
--- a/breakout.html
+++ b/breakout.html
@@ -1,6 +1,6 @@
 <!DOCTYPE html>
 <html>
-
+<meta charset="utf-8"/>
 <head>
     <title>Breakout Clone</title>
     <script src="http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js"></script>


### PR DESCRIPTION
Fix "The character encoding of the HTML document was not declared. Th…e document will render with garbled text in some browser configurations if the document contains characters from outside the US-ASCII range. The character encoding of the page must to be declared in the document or in the transfer protocol."